### PR TITLE
Ensure directory where cache is stored is created.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,6 +40,10 @@ service "varnish" do
   action [ :enable, :start ]
 end
 
+directory "/var/lib/varnish/#{node['varnish']['instance']}" do
+  action :create
+end
+
 service "varnishlog" do
   supports :restart => true, :reload => true
   action [ :enable, :start ]


### PR DESCRIPTION
This has a hardcoded path (/var/lib/varnish), but I think installing from packages on at least redhat/fedora and debian/ubuntu, defaults to cache in this location. Else, just adding this cookbook to the run_list of a host fails !
