### PR TITLE
Varnish should reload instead of restart when vcl config changes.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ template "#{node['varnish']['dir']}/#{node['varnish']['vcl_conf']}" do
   owner "root"
   group "root"
   mode 0644
-  notifies :restart, "service[varnish]"
+  notifies :reload, "service[varnish]"
 end
 
 template node['varnish']['default'] do


### PR DESCRIPTION
Varnish's hot reloading works exceptionally well, we should use that.
