### PR TITLE
Fix for improperly encapsulated bash variable $VARNISH -> ${VARNISH}

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Attributes
 * `node['varnish']['max_threads']` - Start no more then this max amount of threads (500)
 * `node['varnish']['thread_timeout']` - Thread idle timeout (300)
 * `node['varnish']['storage']` - The storage type used ('file')
-* `node['varnish']['storage_file']` -  Specifies either the path to the backing file or the path to a directory in which varnishd will create the backing file. Only used if using file storage. ('/var/lib/varnish/$INSTANCE/varnish_storage.bin')
+* `node['varnish']['storage_file']` -  Specifies either the path to the backing file or the path to a directory in which varnishd will create the backing file. Only used if using file storage. ('/var/lib/varnish/${INSTANCE}/varnish_storage.bin')
 * `node['varnish']['storage_size']` -  Specifies the size of the backing file or max memory allocation.  The size is assumed to be in bytes, unless followed by one of the following suffixes: K,k,M,m,G,g,T,g,% (1G)
 
 If you don't specify your own vcl_conf file, then these attributes are used in the cookbook `default.vcl` template:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@ default['varnish']['min_threads'] ='5'
 default['varnish']['max_threads'] = '500'
 default['varnish']['thread_timeout'] = '300'
 default['varnish']['storage'] = 'file'
-default['varnish']['storage_file'] = '/var/lib/varnish/$INSTANCE/varnish_storage.bin'
+default['varnish']['storage_file'] = '/var/lib/varnish/${INSTANCE}/varnish_storage.bin'
 default['varnish']['storage_size'] = '1G'
 
 default['varnish']['backend_host'] = 'localhost'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures varnish"
-version           "0.9.9"
+version           "0.9.10"
 
 recipe "varnish",      "Installs and configures varnish"
 recipe "varnish::apt_repo", "Adds the official varnish project apt repository"

--- a/templates/default/ubuntu-default.erb
+++ b/templates/default/ubuntu-default.erb
@@ -22,7 +22,7 @@ DAEMON_OPTS="-a :6081 \
              -T localhost:6082 \
              -b localhost:8080 \
              -u varnish -g varnish \
-             -s file,/var/lib/varnish/$INSTANCE/varnish_storage.bin,1G"
+             -s file,/var/lib/varnish/${INSTANCE}/varnish_storage.bin,1G"
 
 
 ## Alternative 2, Configuration with VCL
@@ -34,7 +34,7 @@ DAEMON_OPTS="-a :6081 \
 # DAEMON_OPTS="-a :6081 \
 #              -T localhost:6082 \
 #              -f /etc/varnish/default.vcl \
-#              -s file,/var/lib/varnish/$INSTANCE/varnish_storage.bin,1G"
+#              -s file,/var/lib/varnish/${INSTANCE}/varnish_storage.bin,1G"
 
 
 ## Alternative 3, Advanced configuration
@@ -64,7 +64,7 @@ DAEMON_OPTS="-a :6081 \
 # VARNISH_THREAD_TIMEOUT=120
 #
 # # Cache file location
-# VARNISH_STORAGE_FILE=/var/lib/varnish/$INSTANCE/varnish_storage.bin
+# VARNISH_STORAGE_FILE=/var/lib/varnish/${INSTANCE}/varnish_storage.bin
 #
 # # Cache file size: in bytes, optionally using k / M / G / T suffix,
 # # or in percentage of available disk space using the % suffix.


### PR DESCRIPTION
If the hostname had special characters in it (a '.' for instance) varnish would fail to start.  This escapes the '.'.
