### PR TITLE
Added needed attributes to case statement for CentOS support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ when "debian","ubuntu"
   set['varnish']['default'] = "/etc/default/varnish"
 when "centos","redhat","fedora","scientific"
   set['varnish']['dir']     = "/etc/varnish"
-  set['varnish']['default'] = "/etc/default/varnish"
+  set['varnish']['default'] = "/etc/sysconfig/varnish"
 end
 
 default['varnish']['version'] = "2.1"


### PR DESCRIPTION
This is tested on a Centos 6.4 minimal Vagrant box. It may be presumptuous to include fedora, scientific, etc. but I added at least "centos" so the cookbook would work for my project.
