### PR TITLE
Varnish apt_repo depends on apt cookbook providers

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,8 @@ version           "0.9.13"
 recipe "varnish",      "Installs and configures varnish"
 recipe "varnish::apt_repo", "Adds the official varnish project apt repository"
 
+depends "apt"
+
 %w{ubuntu debian}.each do |os|
   supports os
 end


### PR DESCRIPTION
`varnish::apt_repo` uses `apt_repository` but the `apt` cookbook is not included to provide it.
