### PR TITLE
Fixed string interpolation on template name

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,7 +32,7 @@ template "#{node['varnish']['dir']}/#{node['varnish']['vcl_conf']}" do
   only_if { node['varnish']['vcl_generated'] == true }
 end
 
-template node['varnish']['default'] do
+template "#{node['varnish']['default']}" do
   source 'default.erb'
   owner 'root'
   group 'root'


### PR DESCRIPTION
Current version doesn't compile due to template name interpolation issues:

```
   ArgumentError
   -------------
   You must supply a name when declaring a template resource


   Cookbook Trace:
   ---------------
     /tmp/kitchen/cookbooks/varnish/recipes/default.rb:34:in `from_file'
     /tmp/kitchen/cookbooks/carrenza-varnish/recipes/default.rb:21:in `from_file'
```
