### PR TITLE
Correct repo for Centos 7

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -35,7 +35,7 @@ when 'rhel', 'fedora'
   
   yum_repository 'varnish' do
     description "Varnish #{node['varnish']['version']} repo (#{node['platform_version']} - $basearch)"
-    url myUrl
+    url repoUrl
     gpgcheck false
     gpgkey 'http://repo.varnish-cache.org/debian/GPG-key.txt'
     action 'create'


### PR DESCRIPTION
Repo for EL7 now ommits architecture:
http://repo.varnish-cache.org/redhat/varnish-4.0/el7/repodata/
