### PR TITLE
Add log_daemon attribute configuring varnishlog service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Attributes
 * `node['varnish']['storage']` - The storage type used ('file')
 * `node['varnish']['storage_file']` -  Specifies either the path to the backing file or the path to a directory in which varnishd will create the backing file. Only used if using file storage. ('/var/lib/varnish/$INSTANCE/varnish_storage.bin')
 * `node['varnish']['storage_size']` -  Specifies the size of the backing file or max memory allocation.  The size is assumed to be in bytes, unless followed by one of the following suffixes: K,k,M,m,G,g,T,g,% (1G)
+* `node['varnish']['log_daemon']` -  Specifies if the system `varnishlog` daemon dumping all the varnish logs into `/var/log/varnish/varnish.log` should be enabled. (true)
 * `node['varnish']['parameters']` = Set the parameter specified by param to the specified value. See Run-Time Parameters for a list of parameters. This option can be used multiple times to specifymultiple parameters.
 
 If you don't specify your own vcl_conf file, then these attributes are used in the cookbook `default.vcl` template:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['varnish']['parameters']['thread_pool_timeout'] = '300'
 default['varnish']['storage'] = 'file'
 default['varnish']['storage_file'] = '/var/lib/varnish/$INSTANCE_varnish_storage.bin'
 default['varnish']['storage_size'] = '1G'
+default['varnish']['log_daemon'] = true
 
 default['varnish']['backend_host'] = 'localhost'
 default['varnish']['backend_port'] = '8080'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,5 +48,5 @@ end
 
 service 'varnishlog' do
   supports restart: true, reload: true
-  action %w(enable start)
+  action node['varnish']['log_daemon'] ? %w(enable start) : %w(disable stop)
 end


### PR DESCRIPTION
Hey guys,

We encountered a problem with having varnishlog enabled in our live systems (filling up the disk space quickly with big traffic). 

We disabled it in our wrapper cookbook, but I think it would be nice to have a possibility of disabling that on a community cookbook level using attributes.

Any feedback regarding the pull request is appreciated. 

Thanks,
Kamil & Krzysztof
