### PR TITLE
fix typo in varnish_config portion of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ files that come with your distro package will be used instead.
 | `listen_address` | string | `nil` |
 | `listen_port` | integer | `6081` |
 | `admin_listen_address` | string | `'127.0.0.1'` |
-| `admin_plisten_port` | integer | `6082` |
+| `admin_listen_port` | integer | `6082` |
 | `user` | string | `'varnish'` |
 | `group` | string | `'varnish'` | Only used on varnish versions before 4.1
 | `ccgroup` | string | `nil` | Only used on varnish 4.1


### PR DESCRIPTION
### Description

Fixes typo in the README

### Issues Resolved

admin_plisten_port changed to admin_listen_port
This will alleviate confusion for developers wanting to use this attribute

### Contribution Check List

-- only changed the README, did not run tests

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable