### PR TITLE
Fixing issue #134 where varnishncsa service could not reload

### DIFF
--- a/templates/default/varnishlog_systemd.erb
+++ b/templates/default/varnishlog_systemd.erb
@@ -1,11 +1,12 @@
 [Unit]
-Description=Varnish HTTP accelerator logging daemon
+Description=Varnish Cache HTTP accelerator NCSA logging daemon
 After=varnish.service
 
 [Service]
 Type=forking
 PIDFile=<%= @config.pid %>
 ExecStart=/usr/bin/<%= @config.log_format %> -a -w <%= @config.file_name %> -D -P <%= @config.pid %> -n <%= @config.instance_name %> <%- if @config.ncsa_format_string %> -F <%= @config.ncsa_format_string %> <%- end %>
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description

Template for `varnishncsa.service` in *systemd* was missing the `ExecReload` config.

### Issues Resolved

(#134) 
