### PR TITLE
remove max constraint on apt cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Configures varnish.
 ### chef-client
 
 * Requires chef-client 12.5 and above.
+* If you are using chef-client <12.9 and the `debian` platform family you will need to pin to the 5.X release of the `apt` cookbook.
 
 ### Platforms
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name 'varnish'
 maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs and configures varnish'
 version '3.2.0'
 source_url 'https://github.com/sous-chefs/varnish'

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ recipe 'varnish::repo', 'Adds the official varnish project repository'
   supports os
 end
 
-depends 'apt', '>= 2.4', '< 4.1'
+depends 'apt', '>= 2.4'
 depends 'build-essential'
 depends 'chef-sugar'
 depends 'yum', '>= 3.0', '< 4.1'


### PR DESCRIPTION
### Description

The `apt_repository` was introduced to `chef-client` in 12.9. It was removed from the `apt` cookbook in 6.0. Chef versions `>=12.5 <12.9` can work with `apt >=2.4 <6.0`, and `>=12.9` doesn't need the `apt` cookbook at all.

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable