### PR TITLE
Fix property_name deprecation when running chef-13

### DIFF
--- a/resources/varnish_config.rb
+++ b/resources/varnish_config.rb
@@ -80,7 +80,7 @@ action :configure do
     mode '0644'
     variables(
       major_version: new_resource.major_version,
-      malloc_size: malloc_size || malloc_default,
+      malloc_size: new_resource.malloc_size || malloc_default,
       config: new_resource
     )
     only_if { node['init_package'] == 'systemd' }
@@ -96,7 +96,7 @@ action :configure do
     mode '0644'
     variables(
       major_version: new_resource.major_version,
-      malloc_size: malloc_size || malloc_default,
+      malloc_size: new_resource.malloc_size || malloc_default,
       config: new_resource
     )
     notifies :restart, 'service[varnish]', :delayed


### PR DESCRIPTION
The varnish_config resource was using the property name inside of the
actions, which is deprecated:
- https://docs.chef.io/deprecations_namespace_collisions.html

This commit just renames it to new_resource.malloc_size, which
converges successfully in chef-client 13

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable