### PR TITLE
Update varnish cache repo to packagecloud.io

### DIFF
--- a/resources/varnish_repo_debian.rb
+++ b/resources/varnish_repo_debian.rb
@@ -6,11 +6,13 @@ property :major_version, kind_of: Float, equal_to: [2.1, 3.0, 4.0, 4.1], default
 property :fetch_gpg_key, kind_of: [TrueClass, FalseClass], default: true
 
 action :configure do
+  # packagecloud repos omit dot from major version
+  major_version_no_dot = new_resource.major_version.to_s.tr('.', '')
   apt_repository "varnish-cache_#{new_resource.major_version}" do
-    uri "http://repo.varnish-cache.org/#{node['platform']}"
+    uri "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/#{node['platform']}/"
     distribution node['lsb']['codename']
-    components ["varnish-#{new_resource.major_version}"]
-    key "https://repo.varnish-cache.org/#{node['platform']}/GPG-key.txt" if new_resource.fetch_gpg_key
+    components ['main']
+    key "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/gpgkey" if new_resource.fetch_gpg_key
     deb_src true
     action :add
   end

--- a/resources/varnish_repo_redhat.rb
+++ b/resources/varnish_repo_redhat.rb
@@ -5,9 +5,11 @@ default_action :configure
 property :major_version, kind_of: Float, equal_to: [2.1, 3.0, 4.0, 4.1], default: lazy { node['varnish']['major_version'] }
 
 action :configure do
+  # packagecloud repos omit dot from major version
+  major_version_no_dot = new_resource.major_version.to_s.tr('.', '')
   yum_repository "varnish-cache_#{new_resource.major_version}" do
     description "Varnish #{new_resource.major_version} repo (#{node['platform_version']} - $basearch)"
-    url "http://repo.varnish-cache.org/redhat/varnish-#{new_resource.major_version}/el#{node['platform_version'].to_i}/"
+    url "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/el/#{node['platform_version'].to_i}/$basearch"
     gpgcheck false
     action :create
   end


### PR DESCRIPTION
### Description

The old repository-setup at http://repo.varnish-cache.org/ were scheduled to shut down
on the 31st of August (look like they actually only went offline today), new official project package repositories are hosted at https://packagecloud.io/varnishcache/.

### Issues Resolved

Fix #140

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable