### PR TITLE
Deprecate using the upstream varnish 4 repo on CentOS 7

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -83,7 +83,7 @@ suites:
       major_version: 3.0
 - name: varnish4
   excludes:
-    - centos-7.3
+    - centos-7
     - ubuntu-16.04
   run_list:
     - recipe[install_varnish::test_reqs]

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -83,6 +83,7 @@ suites:
       major_version: 3.0
 - name: varnish4
   excludes:
+    - centos-7.3
     - ubuntu-16.04
   run_list:
     - recipe[install_varnish::test_reqs]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,6 +36,7 @@ suites:
       major_version: 3.0
 - name: varnish4
   excludes:
+    - centos-7.3
     - ubuntu-16.04
   run_list:
     - recipe[install_varnish::vendor_install]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ v3.2.0
 - Fixes default varnishncsa format string (double quotes where getting added).
 - Fixes an conflict when using both varnishlog and varnishncsa.
 - Fixes distro_install integration tests. https://github.com/sous-chefs/varnish/issues/126
-- Reverts the removal of reload-vcl since this is not fixed upstream in ubuntu's system   packages yet.
+- Reverts the removal of reload-vcl since this is not fixed upstream in ubuntu's system packages yet.
+- Updates to the new upstream varnish repo. https://github.com/sous-chefs/varnish/issues/140
+- Deprecates using the upstream varnish 4 repo on CentOS 7 (distro version still works). https://github.com/sous-chefs/varnish/issues/142
 
 v3.1.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ varnish Cookbook CHANGELOG
 ==========================
 This file is used to list changes made in each version of the varnish cookbook.
 
+v3.3.0
+------
+- Updates to the new upstream varnish repo. https://github.com/sous-chefs/varnish/issues/140
+- Deprecates using the upstream varnish 4 repo on CentOS 7 (distro version still works). https://github.com/sous-chefs/varnish/issues/142
+
 v3.2.0
 ------
 - Links /etc/sysconfig/varnishlog and varnishncsa to defaults file in /etc/default. Fixes https://github.com/sous-chefs/varnish/issues/125.
@@ -9,8 +14,6 @@ v3.2.0
 - Fixes an conflict when using both varnishlog and varnishncsa.
 - Fixes distro_install integration tests. https://github.com/sous-chefs/varnish/issues/126
 - Reverts the removal of reload-vcl since this is not fixed upstream in ubuntu's system packages yet.
-- Updates to the new upstream varnish repo. https://github.com/sous-chefs/varnish/issues/140
-- Deprecates using the upstream varnish 4 repo on CentOS 7 (distro version still works). https://github.com/sous-chefs/varnish/issues/142
 
 v3.1.0
 ------

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Tested on the platforms below with distro installs and upstream Varnish packagin
 * CentOS 6.8
   * Tested with 3, 4.0, and 4.1 (distro version is 2.0 which is not supported) 
 * CentOS 7.3
-  * Tested with 4.0 and 4.1 and CentOS 7 distrubution
+  * Tested with 4.1 and the CentOS 7 distrubution version
+  * 4.0 only works with the distro version (https://github.com/sous-chefs/varnish/issues/142)
 
 Other versions may work but require pinning to the correct version which isn't included in this cookbook currently.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license 'Apache-2.0'
 description 'Installs and configures varnish'
-version '3.2.0'
+version '3.3.0'
 source_url 'https://github.com/sous-chefs/varnish'
 issues_url 'https://github.com/sous-chefs/varnish/issues'
 chef_version '>= 12.5' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Deprecate's using the upstream varnish 4 repo on CentOS 7. Varnish 4.0 is EOL (http://varnish-cache.org/releases/), if you are using it you should upgrade to 4.1+ or use the distro version.

### Issues Resolved

Partially addresses https://github.com/sous-chefs/varnish/issues/142

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable