### PR TITLE
Add default TTL value to startup script in systemd

### DIFF
--- a/templates/default/default_systemd.erb
+++ b/templates/default/default_systemd.erb
@@ -28,7 +28,7 @@ EnvironmentFile=/etc/varnish/varnish.params
 Type=forking
 PIDFile=/var/run/varnish.pid
 PrivateTmp=true
-ExecStart=/usr/sbin/varnishd -P /var/run/varnish.pid -f $VARNISH_VCL_CONF -a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} -S $VARNISH_SECRET_FILE -s $VARNISH_STORAGE -n $INSTANCE $DAEMON_OPTS
+ExecStart=/usr/sbin/varnishd -P /var/run/varnish.pid -f $VARNISH_VCL_CONF -a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} -S $VARNISH_SECRET_FILE -s $VARNISH_STORAGE -n $INSTANCE -t $VARNISH_DEFAULT_TTL $DAEMON_OPTS
 
 ExecReload=<%= @config.reload_cmd %>
 

--- a/templates/default/varnish.params.erb
+++ b/templates/default/varnish.params.erb
@@ -36,6 +36,9 @@ VARNISH_STORAGE="<%= storage %>"
 VARNISH_USER=varnish
 VARNISH_GROUP=varnish
 
+# Set the default TTL
+VARNISH_DEFAULT_TTL=<%= @config.ttl %>
+
 INSTANCE=<%= @config.instance_name %>
 
 <%-


### PR DESCRIPTION
### Description

Under systemd, changing the default TTL via the config attribute does not actually change what is configured in varnish. The `-t` flag is not passed to varnishd in `ExecStart`.

This PR adds the `-t` flag in default_systemd.erb, and adds a new env variable `VARNISH_DEFAULT_TTL` in varnish.params.erb (using the `@config.ttl` value).

There currently isn't any test coverage for validating the default TTL, and I'm not sure how the cookbook maintainers would prefer to test this (i.e. do I add a new test suite or update all the current suites?). If I can get some guidance on this, I'd be happy to contribute the tests also.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable