### PR TITLE
Allow all platform_family to set instance name

### DIFF
--- a/templates/default/default.erb
+++ b/templates/default/default.erb
@@ -39,7 +39,7 @@ DAEMON_OPTS=" \
               -f <%= @config.path_to_vcl %> \
               -T <%= @config.admin_listen_address %>:<%= @config.admin_listen_port %> \
               -t <%= @config.ttl %> \
-             <%- if node['platform_family'] == 'debian' %>
+             <%- unless @config.instance_name.nil? || @config.instance_name.empty? %>
               -n $INSTANCE \
              <%- end %>
               -s $STORAGE \


### PR DESCRIPTION
### Description

We don't actually set `-n $INSTANCE` in /etc/sysconfig/varnish unless platform_family is `debian`, however the `-n` flag is available to other platform families.

This PR changes the template so it sets `-n` flag for any platform, but only if `@config.instance_name` is non-empty.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable