### PR TITLE
Allow all platform_family to set instance name in varnishlog

### DIFF
--- a/templates/varnishlog.erb
+++ b/templates/varnishlog.erb
@@ -18,7 +18,7 @@ LOG_FORMAT="<%= @config.ncsa_format_string %>"
 INSTANCE=<%= @config.instance_name %>
 # Override the Daemon options
 DAEMON_OPTS="-a -w $LOGFILE -D -P $PIDFILE \
-             <%- if node['platform_family'] == 'debian' %>
+             <%- unless @config.instance_name.nil? || @config.instance_name.empty? %>
               -n $INSTANCE \
              <%- end %>
 	     <%- if @config.ncsa_format_string %>


### PR DESCRIPTION
### Description

We don't actually set `-n $INSTANCE` in /etc/sysconfig/varnishncsa unless platform_family is `debian`, however the `-n` flag is available to other platform families.

This PR changes the template so it sets `-n` flag for any platform, but only if `@config.instance_name` is non-empty.

(This is basically the same as #153 but for the varnishlog.erb template.)

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable