### PR TITLE
Support more OS/Varnish combinations, more robust Varnish version selection

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -113,9 +113,19 @@ suites:
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::distro_install]
+  attributes:
+    varnish:
+      configure:
+        repo:
+          action: :nothing
 - name: full_stack
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::full_stack]
   excludes:
     - centos-6 # Full stack tests use distro install so need to skip centos-6 for now.
+  attributes:
+    varnish:
+      configure:
+        repo:
+          action: :nothing

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -72,7 +72,6 @@ platforms:
 suites:
 - name: varnish3
   excludes:
-    - centos-7
     - ubuntu-16.04
     - debian-8
   run_list:
@@ -83,8 +82,6 @@ suites:
       major_version: 3.0
 - name: varnish4
   excludes:
-    - centos-7
-    - ubuntu-16.04
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::vendor_install]
@@ -93,7 +90,6 @@ suites:
       major_version: 4.0
 - name: varnish41
   excludes:
-    - ubuntu-16.04
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::vendor_install]

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -74,6 +74,8 @@ suites:
   excludes:
     - ubuntu-16.04
     - debian-8
+    - fedora-latest
+    - opensuse-leap
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::vendor_install]
@@ -82,6 +84,8 @@ suites:
       major_version: 3.0
 - name: varnish4
   excludes:
+    - fedora-latest
+    - opensuse-leap
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::vendor_install]
@@ -90,6 +94,8 @@ suites:
       major_version: 4.0
 - name: varnish41
   excludes:
+    - fedora-latest
+    - opensuse-leap
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::vendor_install]
@@ -97,6 +103,8 @@ suites:
     varnish:
       major_version: 4.1
 - name: varnish5
+  excludes:
+    - opensuse-leap
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::vendor_install]
@@ -106,6 +114,7 @@ suites:
 - name: distro
   excludes:
     - centos-6 # Uses varnish 2 which we don't support
+    - opensuse-leap
   run_list:
     - recipe[install_varnish::test_reqs]
     - recipe[install_varnish::distro_install]
@@ -120,6 +129,7 @@ suites:
     - recipe[install_varnish::full_stack]
   excludes:
     - centos-6 # Full stack tests use distro install so need to skip centos-6 for now.
+    - opensuse-leap
   attributes:
     varnish:
       configure:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,7 +25,6 @@ platforms:
 suites:
 - name: varnish3
   excludes:
-    - centos-7.3
     - ubuntu-16.04
   run_list:
     - recipe[install_varnish::vendor_install]
@@ -33,9 +32,6 @@ suites:
     varnish:
       major_version: 3.0
 - name: varnish4
-  excludes:
-    - centos-7.3
-    - ubuntu-16.04
   run_list:
     - recipe[install_varnish::vendor_install]
   attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,8 +58,18 @@ suites:
     - centos-6.8 # Uses varnish 2 which we don't support
   run_list:
     - recipe[install_varnish::distro_install]
+  attributes:
+    varnish:
+      configure:
+        repo:
+          action: :nothing
 - name: full_stack
   run_list:
     - recipe[install_varnish::full_stack]
   excludes:
     - centos-6.8 # Full stack tests use distro install so need to skip centos-6 for now.
+  attributes:
+    varnish:
+      configure:
+        repo:
+          action: :nothing

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,11 +17,9 @@ platforms:
 - name: centos-7.3
   run_list:
     - recipe[disable_ipv6::disable_ipv6]
-    - recipe[yum-epel]
 - name: centos-6.8
   run_list:
     - recipe[disable_ipv6::disable_ipv6]
-    - recipe[yum-epel]
 
 # Unless other wise noted excludes exist because the distro version get's installed instead (need pinning to support this)
 suites:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,13 @@ env:
   matrix:
     - INSTANCE=varnish3-ubuntu-1404
     - INSTANCE=varnish3-centos-6
+    - INSTANCE=varnish3-centos-7
     - INSTANCE=varnish4-ubuntu-1404
+    - INSTANCE=varnish4-ubuntu-1604
     - INSTANCE=varnish4-centos-6
+    - INSTANCE=varnish4-centos-7
     - INSTANCE=varnish41-ubuntu-1404
+    - INSTANCE=varnish41-ubuntu-1604
     - INSTANCE=varnish41-centos-7
     - INSTANCE=varnish41-centos-6
     - INSTANCE=varnish5-ubuntu-1404

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ varnish Cookbook CHANGELOG
 ==========================
 This file is used to list changes made in each version of the varnish cookbook.
 
+v3.4.1
+------
+- Adds support for Varnish 3 and 4.0 on CentOS 7
+- Adds support for Varnish 4.0 and 4.1 on Ubuntu 1604 
+
 v3.4.0
 ------
 - Adds support Varnish 5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # varnish Cookbook
 
-[![Build Status](https://travis-ci.org/sous-chefs/varnish.svg?branch=master)](https://travis-ci.org/sous-chefs/varnish)  
+[![Build Status](https://travis-ci.org/sous-chefs/varnish.svg?branch=master)](https://travis-ci.org/sous-chefs/varnish)
 [![Cookbook Version](https://img.shields.io/cookbook/v/varnish.svg)](https://supermarket.chef.io/cookbooks/varnish)
 
 Configures varnish.
@@ -14,17 +14,15 @@ Configures varnish.
 
 ### Platforms
 
-Tested on the platforms below with distro installs and upstream Varnish packaging versions 3, 4.0, 4.1, and 5 unless otherwise noted.
+Tested on the platforms below with distro installs and upstream Varnish packaging versions 3.0, 4.0, 4.1, and 5 unless otherwise noted.
 
 
-* Ubuntu 14.04
-* Ubuntu 16.04
-  * Tested with Ubuntu's 16.04 distribution (version 4.1).
-* CentOS 6.8
-  * Tested with 3, 4.0, and 4.1 (distro version is 2.0 which is not supported) 
-* CentOS 7.3
-  * Tested with 4.1 and the CentOS 7 distrubution version
-  * 4.0 only works with the distro version (https://github.com/sous-chefs/varnish/issues/142)
+| Varnish      | 3.0 | 4.0 | 4.1 | 5 | distro |
+|--------------|:---:|:---:|:---:|:-:|:------:|
+| CentOS 6.8   |  ✔  |  ✔  |  ✔  | ✔ |    ✘   |
+| CentOS 7.3   |  ✔  |  ✔  |  ✔  | ✔ |    ✔   |
+| Ubuntu 14.04 |  ✔  |  ✔  |  ✔  | ✔ |    ✔   |
+| Ubuntu 16.04 |  ✘  |  ✔  |  ✔  | ✔ |    ✔   |
 
 Other versions may work but require pinning to the correct version which isn't included in this cookbook currently.
 
@@ -35,7 +33,7 @@ These attributes used as defaults for both resources and the `varnish::configure
 * `node['varnish']['reload_cmd']` - location of the varnish reload script used by the systemd config file. This is not used for initd currently.
 * `node['varnish']['conf_source']` - template file source to use for the `default` varnish init config.
 * `node['varnish']['conf_cookbook']` - template cookbook source to use for the `default` varnish init config.
-* `node['varnish']['major_version']` - the major version of varnish to install. Can be 3.0, 4.0, 4.1, 5 and default's to 4.1.
+* `node['varnish']['major_version']` - the major version of varnish to install. Can be 3.0, 4.0, 4.1, 5 and defaults to 4.1.
 
 Recipes
 -------
@@ -192,7 +190,7 @@ end
 | `mode` | string or integer | `'0644'` | Follows the same behavior as the template resource
 | `variables` | hash | `{}` | Same behavior as the template resource but if the installed varnish major version (3.0, 4.0, 4.1 or 5) can be found it is merged in at @varnish[:installed_version]
 | `varnish_dir` | string | `'/etc/varnish'` | The directory to use for vcl files
-| `vcl_path` | string | `::File.join(varnish_dir, vcl_name)` | Overrides both the vcl_name and varnish_dir if this is specified. 
+| `vcl_path` | string | `::File.join(varnish_dir, vcl_name)` | Overrides both the vcl_name and varnish_dir if this is specified.
 
 #### Example
 Create vcl file at '/etc/varnish/backends.vcl' using the template at 'templates/default/backends.vcl.erb' and pass it some variables:
@@ -221,7 +219,7 @@ end
 | `group` | string | `'root'` |
 | `mode` | string or integer | `'0644'` | Follows the same behavior as the cookbook_file resource
 | `varnish_dir` | string | `'/etc/varnish'` | The directory to use for vcl files
-| `vcl_path` | string | `::File.join(varnish_dir, vcl_name)` | Overrides both the vcl_name and varnish_dir if this is specified. 
+| `vcl_path` | string | `::File.join(varnish_dir, vcl_name)` | Overrides both the vcl_name and varnish_dir if this is specified.
 
 #### Example
 Create vcl file at '/etc/varnish/default.vcl' using the file at 'files/default/default.vcl':

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,11 @@
 default['varnish']['conf_cookbook'] = 'varnish'
 default['varnish']['major_version'] = 4.1
 
+default['varnish']['configure']['repo']['action'] = :configure
+
+# Prevent installation of distro varnish on RHEL/CentOS
+default['yum']['epel']['exclude'] = 'varnish' unless node['varnish']['configure']['repo']['action'].to_sym == :nothing
+
 if platform_family?('debian')
   default['varnish']['conf_path'] = '/etc/default/varnish'
   default['varnish']['reload_cmd'] = '/usr/share/varnish/reload-vcl'
@@ -52,11 +57,6 @@ end
 
 # Disable logs:
 # override['varnish']['configure']['log']['action'] = :nothing
-
-default['varnish']['configure']['repo']['action'] = :configure
-
-# Prevent installation of distro varnish on RHEL/CentOS
-default['yum']['epel']['exclude'] = 'varnish' unless node['varnish']['configure']['repo']['action'].to_sym == :nothing
 
 default['varnish']['configure']['package']['action'] = :install
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@ if platform_family?('debian')
   default['varnish']['conf_path'] = '/etc/default/varnish'
   default['varnish']['reload_cmd'] = '/usr/share/varnish/reload-vcl'
   # Install specific version of Varnish on Debian/Ubuntu
-  default['varnish']['configure']['package']['version'] = "#{node['varnish']['major_version']}.\*"
+  default['varnish']['configure']['package']['version'] = "#{node['varnish']['major_version']}.\*" unless node['varnish']['configure']['repo']['action'].to_sym == :nothing
 else
   default['varnish']['reload_cmd'] = if node['varnish']['major_version'] < 4
                                        '/usr/bin/varnish_reload_vcl'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license 'Apache-2.0'
 description 'Installs and configures varnish'
-version '3.4.0'
+version '3.4.1'
 source_url 'https://github.com/sous-chefs/varnish'
 issues_url 'https://github.com/sous-chefs/varnish/issues'
 chef_version '>= 12.5' if respond_to?(:chef_version)

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -34,12 +34,6 @@ package 'varnish' do
   end
 end
 
-service 'varnish' do
-  node['varnish']['configure']['service'].each do |key, value|
-    send(key, value) unless value.nil?
-  end
-end
-
 varnish_config 'default' do
   node['varnish']['configure']['config'].each do |key, value|
     send(key, value) unless value.nil?
@@ -48,6 +42,12 @@ end
 
 vcl_template 'default.vcl' do
   node['varnish']['configure']['vcl_template'].each do |key, value|
+    send(key, value) unless value.nil?
+  end
+end
+
+service 'varnish' do
+  node['varnish']['configure']['service'].each do |key, value|
     send(key, value) unless value.nil?
   end
 end

--- a/test/integration/distro/serverspec/default_spec.rb
+++ b/test/integration/distro/serverspec/default_spec.rb
@@ -41,7 +41,7 @@ end
 auth_params = '-S /etc/varnish/secret -T 127.0.0.1:6082'
 # Not all distro versions have the backend.list command
 describe command("varnishadm #{auth_params} vcl.show $(varnishadm #{auth_params} vcl.list|sed '/^\s*$/d'|tail -n 1|awk '{print $NF}')") do
-  it 'exits succusfully' do
+  it 'exits successfully' do
     expect(subject.exit_status).to eq 0
   end
   its 'backend is 127.0.0.10:8080' do

--- a/test/integration/varnish3/serverspec/default_spec.rb
+++ b/test/integration/varnish3/serverspec/default_spec.rb
@@ -48,7 +48,7 @@ describe file('/etc/logrotate.d/varnishlog') do
 end
 
 describe command('sudo varnishadm backend.list') do
-  it 'exits succusfully' do
+  it 'exits successfully' do
     expect(subject.exit_status).to eq 0
   end
   its 'backend is 127.0.0.10:8080' do

--- a/test/integration/varnish4/serverspec/default_spec.rb
+++ b/test/integration/varnish4/serverspec/default_spec.rb
@@ -48,7 +48,7 @@ describe file('/etc/logrotate.d/varnishlog') do
 end
 
 describe command('sudo varnishadm backend.list') do
-  it 'exits succusfully' do
+  it 'exits successfully' do
     expect(subject.exit_status).to eq 0
   end
   its 'backend is 127.0.0.10:8080' do

--- a/test/integration/varnish41/serverspec/default_spec.rb
+++ b/test/integration/varnish41/serverspec/default_spec.rb
@@ -48,7 +48,7 @@ describe file('/etc/logrotate.d/varnishlog') do
 end
 
 describe command('sudo varnishadm backend.list') do
-  it 'exits succusfully' do
+  it 'exits successfully' do
     expect(subject.exit_status).to eq 0
   end
   its 'backend is setup' do

--- a/test/integration/varnish5/serverspec/default_spec.rb
+++ b/test/integration/varnish5/serverspec/default_spec.rb
@@ -48,7 +48,7 @@ describe file('/etc/logrotate.d/varnishlog') do
 end
 
 describe command('sudo varnishadm backend.list') do
-  it 'exits succusfully' do
+  it 'exits successfully' do
     expect(subject.exit_status).to eq 0
   end
   its 'backend is setup' do


### PR DESCRIPTION
### Description

This change uses yum repo exclusion to prevent installation of distro varnish on CentOS/RHEL, and passes a `version` string based on `node['varnish']['major_version']` to the package resource on Debian/Ubuntu to ensure installation of the correct version of Varnish.

This change effectively adds support for several previously-unsupported OS/Varnish release combinations. A matrix of supported combinations is present in the updated readme.

More details in individual commit messages.

### Issues Resolved

Resolves:
- #142 
- #160 

Partially resolves #148 — packages are not "pinned" to a repo or version, but the intent of allowing more OS/Varnish combinations to work with the cookbook is achieved through these techniques anyway.

### Contribution Check List

- [✔] All tests pass.
- [✔] New functionality includes testing.
- [✔] New functionality has been documented in the README if applicable

### Notes on tests

I didn't write any unit tests because I did not see anything in the existing test suites that suggests the results from different attribute settings are tested currently. The outcomes are fully covered in the integration tests, so I'm guessing that is considered appropriate for the project.