### PR TITLE
Fix test failures on Chef 12

### DIFF
--- a/test/fixtures/cookbooks/install_varnish/recipes/full_stack.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/full_stack.rb
@@ -1,4 +1,4 @@
-apt_update
+apt_update 'update apt cache'
 
 include_recipe 'yum-epel'
 include_recipe 'varnish::default'


### PR DESCRIPTION
Chef 13+ allows apt_update to have no name, but we're on Chef 12.X

Signed-off-by: Tim Smith <tsmith@chef.io>