### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb      # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,10 @@
-# Limitations
+# AGENTS.md
+
+## Agent Guidance
+
+This cookbook uses `Policyfile.rb` for dependency resolution. Run `chef install Policyfile.rb`
+after changing cookbook dependencies or test cookbook recipes, and keep Kitchen suites mapped to
+Policyfile named run lists.
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,0 +1,139 @@
+{
+  "revision_id": "fdd2c5203fbea00951d8183f0b6172dcadf8b1a7ce604a4f2e348c0cfd1f19d1",
+  "name": "varnish",
+  "run_list": [
+    "recipe[test::default]"
+  ],
+  "named_run_lists": {
+    "default": [
+      "recipe[test::default]"
+    ],
+    "distro": [
+      "recipe[test::distro]"
+    ],
+    "full_stack": [
+      "recipe[test::full_stack]"
+    ]
+  },
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "test": {
+      "version": "0.0.1",
+      "identifier": "9f51b46453623e5e00569cfca8df877c3044c59d",
+      "dotted_decimal_identifier": "44844356516143678.26459019811793119.148967455507869",
+      "source": "test/cookbooks/test",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "9ad5350b254332e6f7c8a02ab618b5546d4be096",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main",
+          "origin/renovate/actions"
+        ]
+      },
+      "source_options": {
+        "path": "test/cookbooks/test"
+      }
+    },
+    "varnish": {
+      "version": "6.0.0",
+      "identifier": "ac07b0c01fca0a67acabb916c3e14e0b9f162215",
+      "dotted_decimal_identifier": "48422151713180170.29181776145859553.85811820634645",
+      "source": ".",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "9ad5350b254332e6f7c8a02ab618b5546d4be096",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main",
+          "origin/renovate/actions"
+        ]
+      },
+      "source_options": {
+        "path": "."
+      }
+    },
+    "yum": {
+      "version": "8.0.0",
+      "identifier": "a4f3da1691d5c1bcd08e339bed45d3babcbf420a",
+      "dotted_decimal_identifier": "46430014187623873.53146604791393605.232798984028682",
+      "cache_key": "yum-8.0.0-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/yum/versions/8.0.0/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/yum/versions/8.0.0/download",
+        "version": "8.0.0"
+      }
+    },
+    "yum-epel": {
+      "version": "5.0.9",
+      "identifier": "e001464b1be96e91578d9f2eae7db84345d2c611",
+      "dotted_decimal_identifier": "63051796202645870.40910137395687037.202599073760785",
+      "cache_key": "yum-epel-5.0.9-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/yum-epel/versions/5.0.9/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/yum-epel/versions/5.0.9/download",
+        "version": "5.0.9"
+      }
+    }
+  },
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "test",
+        ">= 0.0.0"
+      ],
+      [
+        "varnish",
+        ">= 0.0.0"
+      ],
+      [
+        "yum",
+        "= 8.0.0"
+      ],
+      [
+        "yum-epel",
+        "= 5.0.9"
+      ]
+    ],
+    "dependencies": {
+      "test (0.0.1)": [
+        [
+          "varnish",
+          ">= 0.0.0"
+        ]
+      ],
+      "varnish (6.0.0)": [
+        [
+          "yum",
+          ">= 7.2.0"
+        ],
+        [
+          "yum-epel",
+          ">= 0.0.0"
+        ]
+      ],
+      "yum (8.0.0)": [
+
+      ],
+      "yum-epel (5.0.9)": [
+
+      ]
+    }
+  }
+}

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'varnish'
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'varnish', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Requires Chef Infra Client 15.3 and above.
 
 ### Platforms
 
-See [LIMITATIONS.md](LIMITATIONS.md) for package availability and platform notes.
+See [AGENTS.md](AGENTS.md) for package availability and platform notes.
 
 ## Breaking Migration
 

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,8 +3,12 @@ driver:
   privileged: true
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
-transport: { name: dokken }
-provisioner: { name: dokken }
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  policyfile: Policyfile.rb
 
 platforms:
   - name: almalinux-8

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -4,6 +4,7 @@ provisioner:
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
+  policyfile: Policyfile.rb
   install_strategy: once
   chef_license: accept
   enforce_idempotency: <%= ENV['ENFORCE_IDEMPOTENCY'] || true %>

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
   product_name: chef
   product_version: latest
   channel: stable
+  policyfile: Policyfile.rb
   deprecations_as_errors: true
   enforce_idempotency: true
   multiple_converge: 2
@@ -28,14 +29,6 @@ platforms:
   - name: ubuntu-22.04
   - name: ubuntu-24.04
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-  distro: &distro_run_list
-    - recipe[test::distro]
-  full_stack: &full_stack_run_list
-    - recipe[test::full_stack]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -43,11 +36,13 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier
 
   - name: distro
-    run_list: *distro_run_list
+    provisioner:
+      named_run_list: distro
     verifier:
       inspec_tests:
         - path: test/integration/default
@@ -55,7 +50,8 @@ suites:
         ncsa_format_string: true
 
   - name: full_stack
-    run_list: *full_stack_run_list
+    provisioner:
+      named_run_list: full_stack
     verifier:
       inspec_tests:
         - path: test/integration/default

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 require_relative '../libraries/helpers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary
- replace Berksfile dependency resolution with Policyfile.rb and a generated Policyfile.lock.json
- switch ChefSpec and Kitchen/Copilot setup to Policyfile support and named run lists
- move package/platform notes from LIMITATIONS.md into AGENTS.md and update related guidance

## Validation
- chef install Policyfile.rb
- cookstyle
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- actionlint
- yamllint .
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md"
- git diff --check

Note: plain chef exec rspec is blocked on this workstation by a local macOS code-signing failure in /Users/damacus/.chef/gem/ruby/3.1.0/gems/json-2.20.0, so specs were verified with Chef Workstation's embedded gem path.